### PR TITLE
Support cd with no args to go to home dir.

### DIFF
--- a/app/builtins/cd.rb
+++ b/app/builtins/cd.rb
@@ -6,7 +6,7 @@ unless Hedgehog::Settings
 
   function "cd" do |args|
     begin
-      dir = args.to_s.shellsplit.first.chomp
+      dir = args.to_s.shellsplit.first&.chomp || ENV['HOME']
       dir = ENV['OLDPWD'] if dir == "-"
 
       ENV['OLDPWD'] = Dir.pwd


### PR DESCRIPTION
`cd` == `cd ~`